### PR TITLE
(re)Generate tcsh_completion_script  w/  'set noclobber'

### DIFF
--- a/contrib/completion/git-completion.tcsh
+++ b/contrib/completion/git-completion.tcsh
@@ -41,7 +41,7 @@ if ( ! -e ${__git_tcsh_completion_original_script} ) then
 	exit
 endif
 
-cat << EOF > ${__git_tcsh_completion_script}
+cat << EOF >! ${__git_tcsh_completion_script}
 #!bash
 #
 # This script is GENERATED and will be overwritten automatically.


### PR DESCRIPTION
tcsh users who happen to have `set noclobber` elsewhere in their `~/.tcshrc` or `~/.cshrc` startup files get a `File exists` error, and the tcsh completion file doesn't get generated/updated.  Adding a `!` in the redirect works correctly for both clobber and noclobber users.
